### PR TITLE
Fix an infinite loop issue

### DIFF
--- a/src/chemistry/pp_geoschem/mo_sim_dat.F90
+++ b/src/chemistry/pp_geoschem/mo_sim_dat.F90
@@ -28,13 +28,13 @@
 !--------------------------------------------------------------
       integer :: ios
 
-      is_scalar = .false.
-      is_vector = .true.
+      ! is_scalar = .false.
+      ! is_vector = .true.
 
-      clscnt(:) = (/     30,     0,     0,   191,     0 /)
+      ! clscnt(:) = (/     30,     0,     0,   191,     0 /)
 
-      cls_rxt_cnt(:,1) = (/     37,    61,     0,    30 /)
-      cls_rxt_cnt(:,4) = (/     23,   174,   326,   191 /)
+      ! cls_rxt_cnt(:,1) = (/     37,    61,     0,    30 /)
+      ! cls_rxt_cnt(:,4) = (/     23,   174,   326,   191 /)
 
       solsym(:273) = (/ 'CH2I2          ','CH2ICL         ','CH2IBR         ', &
                         'NITs           ','NIT            ','AERI           ', &

--- a/src/chemistry/pp_geoschem/mo_tracname.F90
+++ b/src/chemistry/pp_geoschem/mo_tracname.F90
@@ -5,10 +5,13 @@
 !           surface fluxes for the advected species.
 !-----------------------------------------------------------
 
-      use chem_mods, only : grpcnt, gas_pcnst
+      use chem_mods, only : nTracersMax
 
       implicit none
 
-      character(len=16) :: solsym(gas_pcnst)   ! species names
+! modified to an arbitrary high #, was gas_pcnst. this would cause a memory
+! overflow overwrite in mo_sim_dat, which allocates :273 larger than
+! the default specified gas_pcnst (hplin, 5/16/20)
+      character(len=16) :: solsym(273)   ! species names
 
       end module mo_tracname


### PR DESCRIPTION
Fix: Comment out `mo_sim_dat` except `solsym` assignment, expand solsym size to 273 (which is the size in `mo_sim_dat`)

This might not be needed after all as HEMCO_CESM now reads tracer names from chem_mods. But fixing this so it doesn't infinite loop.

This needs to be applied if you see `atm.log...` stuck on `VOLC_MMR` or something. Reason unknown but this should fix it.

Thanks!