### PR TITLE
Fix: Edge case for Hr Mn Sc calculator

### DIFF
--- a/src/chemistry/pp_geoschem/chemistry.F90
+++ b/src/chemistry/pp_geoschem/chemistry.F90
@@ -2867,11 +2867,11 @@ contains
     currSc  = 0
     currMn  = 0
     currHr  = 0
-    DO WHILE (currTOD > 3600)
+    DO WHILE (currTOD >= 3600)
         currTOD = currTOD - 3600
         currHr  = currHr + 1
     ENDDO
-    DO WHILE (currTOD > 60)
+    DO WHILE (currTOD >= 60)
         currTOD = currTOD - 60
         currMn  = currMn + 1
     ENDDO


### PR DESCRIPTION
Hi Thibaud,

When `currTOD = 3600` the hour calculation code in `chemistry.F90` will compute `00:59:60` as the time instead of `01:00:00`. This is due to the omission of a couple equal signs:

```fortran
    ! Deal with subdaily
    currUTC = REAL(currTOD,f4)/3600.0e+0_f4
    currSc  = 0
    currMn  = 0
    currHr  = 0
    DO WHILE (currTOD > 3600) ! here
        currTOD = currTOD - 3600
        currHr  = currHr + 1
    ENDDO
    DO WHILE (currTOD > 60) ! ...and here
        currTOD = currTOD - 60
        currMn  = currMn + 1
    ENDDO
```

Please find attached this small fix. Thanks!

Best,
Haipeng